### PR TITLE
I changed the php7 repo, because the original one is no longer in use.

### DIFF
--- a/docker-ubuntu-upstart/script_base/build_default_pack.sh
+++ b/docker-ubuntu-upstart/script_base/build_default_pack.sh
@@ -5,7 +5,7 @@ source /root/script_base.sh
 
 # REPOS
 apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 0x4f4ea0aae5267a6c
-echo "deb http://ppa.launchpad.net/ondrej/php" > /etc/apt/sources.list.d/php7.list
+echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu trusty main" > /etc/apt/sources.list.d/php7.list
 
 # php5.6
 sudo add-apt-repository ppa:ondrej/php5-5.6 -y

--- a/docker-ubuntu-upstart/script_base/build_default_pack.sh
+++ b/docker-ubuntu-upstart/script_base/build_default_pack.sh
@@ -5,7 +5,7 @@ source /root/script_base.sh
 
 # REPOS
 apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 0x4f4ea0aae5267a6c
-echo "deb http://ppa.launchpad.net/ondrej/php-7.0/ubuntu trusty main" > /etc/apt/sources.list.d/php7.list
+echo "deb http://ppa.launchpad.net/ondrej/php" > /etc/apt/sources.list.d/php7.list
 
 # php5.6
 sudo add-apt-repository ppa:ondrej/php5-5.6 -y


### PR DESCRIPTION
I was going to create an issue, but I thought I would do a pull request. The original php7 repo is not longer being used.  When I try to build my docker container off of labengine it fails at the php7 point.  

You can use what I have or develop your own solution, if you don't like mine. 

Thanks.
